### PR TITLE
rollback to go1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kshard/vector
 
-go 1.22.0
+go 1.21.3
 
 require (
 	github.com/chewxy/math32 v1.10.1


### PR DESCRIPTION
No hard requirments for go1.22 usage.
VS Code fails to work correctly with v1.22